### PR TITLE
Fix codacy warnings by changing lint rules

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,7 @@
   "browser": true,
   "boss": true,
   "curly": true,
-  "debug": false,
+  "debug": true,
   "devel": true,
   "eqeqeq": true,
   "evil": true,
@@ -16,7 +16,7 @@
   "laxbreak": false,
   "newcap": true,
   "noarg": true,
-  "noempty": false,
+  "noempty": true,
   "nonew": false,
   "nomen": false,
   "onevar": false,
@@ -27,6 +27,8 @@
   "strict": false,
   "white": false,
   "eqnull": true,
+  "es5": false,
+  "esnext": true,
   "esversion": 6,
   "unused": true
 }

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,6 +47,7 @@
   "strict": false,
   "white": false,
   "eqnull": true,
+  "esnext": true,
   "esversion": 6,
   "unused": true
 }


### PR DESCRIPTION
It was mistake to replace addon's `.jshint` by `.jshint` file from the latest ember version. The codacy emit a lot of warnings after that, because it doesn't understand option `esversion`.

The `esnext` flag is returned.