### PR TITLE
Changed argument options to undefined

### DIFF
--- a/tests/dummy/app/controllers/cookbook/animation.js
+++ b/tests/dummy/app/controllers/cookbook/animation.js
@@ -8,7 +8,7 @@ export default Ember.Controller.extend({
       this.get("dialog").alert(hbs`Dialog's body`, this);
     },
     showAnimatedDialog() {
-      this.get("dialog").alert(hbs`Dialog's body`, this, null, "presenter-animated");
+      this.get("dialog").alert(hbs`Dialog's body`, this, undefined, "presenter-animated");
     },
     showAnimation(animationToShow, animationToHide, delay=1000) {
       this.get("dialog").alert(hbs`Dialog's body`, this, {animationToShow, animationToHide, delay}, "presenter-animate-css");


### PR DESCRIPTION
Argument `options` changed to `undefined`, because default value (empty hash) is not set in `show` method and it throws error when trying to get id from `undefined` variable.