### PR TITLE
Ember 1.13 is not supported any more

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,28 +4,6 @@ module.exports = {
   useVersionCompatibility: true,
   scenarios: [
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      }
-    },
-    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "demoURL": "http://wheely.github.io/ember-dialog/",
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">1.13.12"
+      "ember": ">2.3.2"
     }
   }
 }


### PR DESCRIPTION
From now on `ember-dialog` compatible with `ember@v2.3.2` and above. The `ember try:each` will run tests with `ember` greater then `v2.3.2`.