### PR TITLE
Fix codacy warning by changing lint rules

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,7 @@
   "browser": true,
   "boss": true,
   "curly": true,
-  "debug": false,
+  "debug": true,
   "devel": true,
   "eqeqeq": true,
   "evil": true,
@@ -16,7 +16,7 @@
   "laxbreak": false,
   "newcap": true,
   "noarg": true,
-  "noempty": false,
+  "noempty": true,
   "nonew": false,
   "nomen": false,
   "onevar": false,
@@ -27,6 +27,7 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esversion": 6,
+  "es5": false,
+  "esnext": true,
   "unused": true
 }

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -27,7 +27,7 @@
   "browser": false,
   "boss": true,
   "curly": true,
-  "debug": false,
+  "debug": true,
   "devel": false,
   "eqeqeq": true,
   "evil": true,
@@ -36,7 +36,7 @@
   "laxbreak": false,
   "newcap": true,
   "noarg": true,
-  "noempty": false,
+  "noempty": true,
   "nonew": false,
   "nomen": false,
   "onevar": false,
@@ -47,6 +47,7 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esversion": 6,
+  "es5": false,
+  "esnext": true,
   "unused": true
 }


### PR DESCRIPTION
It was mistake to replace addon's `.jshint` by `.jshint` file from the latest ember version. The codacy emit a lot of warnings after that, because it doesn't understand option `esversion`.

The `esnext` flag is returned.